### PR TITLE
Improve UI for 1024x600 kiosk screens

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,7 @@
             background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             min-height: 100vh;
+            margin: 0;
             touch-action: manipulation;
         }
         
@@ -131,9 +132,26 @@
                 padding: 12px 20px;
                 min-height: 50px;
             }
-            
+
             .countdown {
                 font-size: 6em;
+            }
+        }
+
+        /* Ajustements pour écran kiosk 1024x600 */
+        @media (max-width: 1024px) and (max-height: 600px) {
+            .container-fluid {
+                padding: 10px;
+            }
+
+            .btn {
+                font-size: 0.95em;
+                padding: 10px 16px;
+                min-height: 48px;
+            }
+
+            .countdown {
+                font-size: 5em;
             }
         }
     </style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,8 +12,7 @@
              alt="Flux vidéo caméra">
         
         <!-- Countdown overlay -->
-        <div class="countdown d-none position-absolute top-50 start-50 translate-middle" id="countdown" 
-             style="font-size: 15rem; font-weight: bold; color: white; text-shadow: 3px 3px 6px rgba(0,0,0,0.8); z-index: 10;"></div>
+        <div class="countdown d-none position-absolute top-50 start-50 translate-middle" id="countdown"></div>
         
         <!-- Flash blanc pour la prise de photo -->
         <div class="flash-overlay d-none position-fixed top-0 start-0 w-100 h-100" id="flashOverlay" 


### PR DESCRIPTION
## Summary
- tweak body style to remove margin
- add 1024x600 responsive tweaks
- rely on CSS for countdown instead of inline style

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6867fbbb2ffc8332892ffd67425562ab